### PR TITLE
Adjust require() paths

### DIFF
--- a/control/guiComponents.lua
+++ b/control/guiComponents.lua
@@ -1,4 +1,4 @@
-local util = require("./util.lua")
+local util = require("control/util.lua")
 
 local guis = {}
 

--- a/control/server.lua
+++ b/control/server.lua
@@ -1,6 +1,6 @@
-local util = require("./util.lua")
-local guis = require("./guiComponents.lua")
-local guiControl = require("./guiControl.lua")
+local util = require("control/util.lua")
+local guis = require("control/guiComponents.lua")
+local guiControl = require("control/guiControl.lua")
 
 local function NetworkCreationGui(info)
     local newgui = info.parent.add({

--- a/control/util.lua
+++ b/control/util.lua
@@ -1,4 +1,4 @@
-local gc = require("./guiControl.lua")
+local gc = require("control/guiControl.lua")
 
 local util = {}
 

--- a/data/entities.lua
+++ b/data/entities.lua
@@ -1,1 +1,1 @@
-require("./entities/server.lua")
+require("data/entities/server.lua")

--- a/data/items.lua
+++ b/data/items.lua
@@ -1,1 +1,1 @@
-require("./items/server.lua")
+require("data/items/server.lua")

--- a/data/research.lua
+++ b/data/research.lua
@@ -1,1 +1,1 @@
-require("./research/network-fundamentals.lua")
+require("data/research/network-fundamentals.lua")

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "digital-storage",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "title": "Digital Storage",
     "author": "Azrael",
     "contact": "Azrael#1123 on discord; t-brieger@gmx.de",


### PR DESCRIPTION
`./` doesn't work properly when the mod is zipped.

All calls to `require()` are relative to the mod root allowing for consistent behavior whether the mod is zipped or not.

Also bumps the version number to `0.0.3`.